### PR TITLE
Add WS2S CLI integration docs

### DIFF
--- a/docs/cli/ws2s_integration.md
+++ b/docs/cli/ws2s_integration.md
@@ -1,0 +1,34 @@
+# WS2S CLI Integration
+
+This document outlines the proposed "What You See Is What You See" (WS2S) paradigm for the LibPolyCall command line interface.
+
+## Goals
+- Provide real time visual feedback for every CLI command.
+- Ensure command semantics are clear (WYSIWYM: What You See Is What You Mean).
+- Maintain OBINexus constitutional compliance and accessibility.
+
+## Command Pattern
+Each command follows the pattern:
+
+```bash
+./polycall <domain> <action> <target> [options]
+```
+
+Example:
+
+```bash
+./polycall protocol init --guid=auto --telemetry=enabled
+```
+
+## Visual Feedback
+A small progress indicator should reflect completion percentage along with constitutional status indicators:
+
+```
+[●●●○○] 40% | protocol init | GUID: <id> | ✓ Constitutional | ✓ A11Y
+```
+
+## Accessibility
+Output should be screen‑reader friendly and optionally provide audio notifications. High contrast mode should be available when the terminal supports it.
+
+## Dark Psychology Mitigation
+Commands must disclose their intent before execution and request explicit consent for sensitive operations.


### PR DESCRIPTION
## Summary
- document the WS2S CLI integration guidelines under docs/cli

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ec816d04c83278d4c4b9f5127aaa8