### PR TITLE
Add adapter integration & 4-agent workflow docs

### DIFF
--- a/docs/code_ai_4agent_task_framework.md
+++ b/docs/code_ai_4agent_task_framework.md
@@ -1,0 +1,23 @@
+# Code AI 4-Agent Task Distribution Framework
+
+This reference describes the multi-agent workflow used when developing LibPolyCall with automated assistance.
+
+## Agent Roles
+
+1. **Core Developer** – implements core C functionality, topology management and validation engine.
+2. **API Developer & Integration Specialist** – maintains language bindings, daemon support and cross-language APIs.
+3. **QA Engineer & Unit Test Developer** – provides unit tests, integration tests and security audits with >90% coverage targets.
+4. **QA Analyst & Documentation Specialist** – ensures integration tests across bindings, produces documentation and coverage reports.
+
+## Collaboration Process
+
+Development proceeds in phases. Core infrastructure is built first, followed by testing frameworks, language bindings and finally documentation. Each commit is reviewed across agents to maintain code quality and consistent documentation.
+
+## Quality Gates
+
+- All unit tests must pass
+- Test coverage should exceed 90%
+- No memory leaks or thread safety issues
+- Documentation must accompany public APIs
+
+The framework encourages daily synchronization, reference to task numbers in commits and continuous reporting of test results and issues.

--- a/docs/hotwiring-architecture/hotwiring_adapter_integration.md
+++ b/docs/hotwiring-architecture/hotwiring_adapter_integration.md
@@ -1,0 +1,37 @@
+# Hotwiring Adapter Integration Specification
+
+This document outlines the proposed adapter layer used to bridge LibPolyCall's C runtime with language specific bindings. It consolidates the architecture description from the *Hotwiring Adapter Integration Specification for LibPolyCall*.
+
+## Base C Adapter Interface
+
+The adapter layer defines a common `adapter_base_t` structure with a vtable for lifecycle functions. The interface maintains a `topology_manager_t` pointer, an atomic reference count and thread safety primitives. Key API functions include:
+
+- `adapter_base_init`
+- `adapter_base_acquire`
+- `adapter_base_release`
+- `adapter_execute_transition`
+
+These functions provide safe initialization and transition execution for all language bindings.
+
+## Language-Specific Implementations
+
+Implementations for Python (CFFI), Go (CGO) and Node.js (N-API) are provided as examples. Each adapter embeds `adapter_base_t` and implements `enter_layer` to coordinate with its respective runtime. The design ensures that entering a new layer validates the transition using `adapter_execute_transition` before invoking language specific callbacks or event queues.
+
+```c
+typedef struct python_adapter {
+    adapter_base_t base;
+    PyObject* callback_dict;
+    PyGILState_STATE gil_state;
+} python_adapter_t;
+```
+
+The Go adapter ensures transitions occur on the owning OS thread to satisfy CGO restrictions, while the Node.js adapter schedules asynchronous notifications to the event loop using `uv_async_t`.
+
+## Unified Adapter Registry
+
+A global `adapter_registry_t` maintains registered adapters for each topology layer and coordinates transitions between them. The `adapter_orchestrate_transition` function demonstrates a thread-safe approach to exiting one layer and entering another using the registry.
+
+## Testing Considerations
+
+Unit tests should verify thread safety, reference counting and correct transition validation across adapters. Integration tests focus on cross-language transitions to guarantee consistent behaviour.
+


### PR DESCRIPTION
## Summary
- document hotwiring adapter integration
- document the 4-agent Code AI task distribution framework

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6862aab1eb2c83278c25dcdd1b7b4274