### PR TITLE
Add hotwiring adapter skeleton

### DIFF
--- a/libpolycall/docs/hotwiring_adapter_spec.md
+++ b/libpolycall/docs/hotwiring_adapter_spec.md
@@ -1,0 +1,22 @@
+# Hotwiring Adapter Integration Specification
+
+This document outlines the core structures for the hotwiring adapter layer. The adapter layer provides a unified interface for language-specific bindings to interact with the core topology manager.
+
+## Structures
+
+The primary interface is defined in `adapter_base.h`:
+
+```c
+typedef struct adapter_vtable {
+    int (*init)(void* adapter, struct topology_manager* manager);
+    int (*enter_layer)(void* adapter, uint64_t thread_id, uint32_t layer_id);
+    int (*exit_layer)(void* adapter, uint64_t thread_id);
+    int (*validate_transition)(void* adapter, uint32_t from, uint32_t to);
+    int (*emit_trace)(void* adapter, struct trace_event* event);
+    int (*cleanup)(void* adapter);
+} adapter_vtable_t;
+```
+
+Language specific adapters extend `adapter_base_t` and provide implementations for these callbacks.
+
+See `src/core/adapters` for the initial skeleton implementation.

--- a/libpolycall/include/polycall/core/adapters/adapter_base.h
+++ b/libpolycall/include/polycall/core/adapters/adapter_base.h
@@ -1,0 +1,45 @@
+#ifndef ADAPTER_BASE_H
+#define ADAPTER_BASE_H
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct topology_manager;
+struct trace_event;
+
+typedef struct adapter_vtable {
+    int (*init)(void* adapter, struct topology_manager* manager);
+    int (*enter_layer)(void* adapter, uint64_t thread_id, uint32_t layer_id);
+    int (*exit_layer)(void* adapter, uint64_t thread_id);
+    int (*validate_transition)(void* adapter, uint32_t from, uint32_t to);
+    int (*emit_trace)(void* adapter, struct trace_event* event);
+    int (*cleanup)(void* adapter);
+} adapter_vtable_t;
+
+typedef struct adapter_base {
+    adapter_vtable_t* vtable;
+    struct topology_manager* manager;
+    atomic_int ref_count;
+    pthread_mutex_t mutex;
+    void* language_specific_data;
+    uint32_t adapter_layer_id;
+} adapter_base_t;
+
+int adapter_base_init(adapter_base_t* adapter, struct topology_manager* manager);
+int adapter_base_acquire(adapter_base_t* adapter);
+int adapter_base_release(adapter_base_t* adapter);
+
+int adapter_execute_transition(adapter_base_t* adapter,
+                               uint64_t thread_id,
+                               uint32_t target_layer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADAPTER_BASE_H */

--- a/libpolycall/include/polycall/core/adapters/adapter_orchestrator.h
+++ b/libpolycall/include/polycall/core/adapters/adapter_orchestrator.h
@@ -1,0 +1,20 @@
+#ifndef ADAPTER_ORCHESTRATOR_H
+#define ADAPTER_ORCHESTRATOR_H
+
+#include <stdint.h>
+#include "polycall/core/adapters/adapter_registry.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int adapter_orchestrate_transition(adapter_registry_t* registry,
+                                   uint64_t thread_id,
+                                   uint32_t from_layer,
+                                   uint32_t to_layer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADAPTER_ORCHESTRATOR_H */

--- a/libpolycall/include/polycall/core/adapters/adapter_registry.h
+++ b/libpolycall/include/polycall/core/adapters/adapter_registry.h
@@ -1,0 +1,28 @@
+#ifndef ADAPTER_REGISTRY_H
+#define ADAPTER_REGISTRY_H
+
+#include <pthread.h>
+#include <stdint.h>
+#include "polycall/core/adapters/adapter_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TOPOLOGY_LAYER_MAX 32
+
+typedef struct adapter_registry {
+    adapter_base_t* adapters[TOPOLOGY_LAYER_MAX];
+    pthread_rwlock_t rwlock;
+    struct topology_manager* manager;
+} adapter_registry_t;
+
+int adapter_registry_init(adapter_registry_t* registry, struct topology_manager* manager);
+int adapter_registry_register(adapter_registry_t* registry, uint32_t layer_id, adapter_base_t* adapter);
+adapter_base_t* adapter_registry_get(adapter_registry_t* registry, uint32_t layer_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADAPTER_REGISTRY_H */

--- a/libpolycall/src/core/adapters/adapter_base.c
+++ b/libpolycall/src/core/adapters/adapter_base.c
@@ -1,0 +1,47 @@
+#include "polycall/core/adapters/adapter_base.h"
+
+int adapter_base_init(adapter_base_t* adapter, struct topology_manager* manager)
+{
+    if (!adapter || !manager) return -1;
+    adapter->manager = manager;
+    atomic_init(&adapter->ref_count, 1);
+    pthread_mutex_init(&adapter->mutex, NULL);
+    adapter->language_specific_data = NULL;
+    return 0;
+}
+
+int adapter_base_acquire(adapter_base_t* adapter)
+{
+    if (!adapter) return -1;
+    atomic_fetch_add_explicit(&adapter->ref_count, 1, memory_order_relaxed);
+    return 0;
+}
+
+int adapter_base_release(adapter_base_t* adapter)
+{
+    if (!adapter) return -1;
+    if (atomic_fetch_sub_explicit(&adapter->ref_count, 1, memory_order_acq_rel) == 1) {
+        if (adapter->vtable && adapter->vtable->cleanup) {
+            adapter->vtable->cleanup(adapter);
+        }
+        pthread_mutex_destroy(&adapter->mutex);
+    }
+    return 0;
+}
+
+int adapter_execute_transition(adapter_base_t* adapter,
+                               uint64_t thread_id,
+                               uint32_t target_layer)
+{
+    if (!adapter || !adapter->vtable) return -1;
+    if (adapter->vtable->validate_transition) {
+        int res = adapter->vtable->validate_transition(adapter,
+                                                       adapter->adapter_layer_id,
+                                                       target_layer);
+        if (res != 0) return res;
+    }
+    if (adapter->vtable->enter_layer) {
+        return adapter->vtable->enter_layer(adapter, thread_id, target_layer);
+    }
+    return 0;
+}

--- a/libpolycall/src/core/adapters/adapter_orchestrator.c
+++ b/libpolycall/src/core/adapters/adapter_orchestrator.c
@@ -1,0 +1,27 @@
+#include "polycall/core/adapters/adapter_orchestrator.h"
+
+int adapter_orchestrate_transition(adapter_registry_t* registry,
+                                   uint64_t thread_id,
+                                   uint32_t from_layer,
+                                   uint32_t to_layer)
+{
+    if (!registry) return -1;
+    pthread_rwlock_rdlock(&registry->rwlock);
+    adapter_base_t* from_adapter = adapter_registry_get(registry, from_layer);
+    adapter_base_t* to_adapter = adapter_registry_get(registry, to_layer);
+    pthread_rwlock_unlock(&registry->rwlock);
+
+    if (!from_adapter || !to_adapter) {
+        return -1;
+    }
+
+    int result = 0;
+    if (from_adapter->vtable && from_adapter->vtable->exit_layer) {
+        result = from_adapter->vtable->exit_layer(from_adapter, thread_id);
+        if (result != 0) return result;
+    }
+    if (to_adapter->vtable && to_adapter->vtable->enter_layer) {
+        result = to_adapter->vtable->enter_layer(to_adapter, thread_id, to_layer);
+    }
+    return result;
+}

--- a/libpolycall/src/core/adapters/adapter_registry.c
+++ b/libpolycall/src/core/adapters/adapter_registry.c
@@ -1,0 +1,31 @@
+#include "polycall/core/adapters/adapter_registry.h"
+
+int adapter_registry_init(adapter_registry_t* registry, struct topology_manager* manager)
+{
+    if (!registry) return -1;
+    registry->manager = manager;
+    for (int i = 0; i < TOPOLOGY_LAYER_MAX; ++i) {
+        registry->adapters[i] = NULL;
+    }
+    pthread_rwlock_init(&registry->rwlock, NULL);
+    return 0;
+}
+
+int adapter_registry_register(adapter_registry_t* registry, uint32_t layer_id, adapter_base_t* adapter)
+{
+    if (!registry || layer_id >= TOPOLOGY_LAYER_MAX) return -1;
+    pthread_rwlock_wrlock(&registry->rwlock);
+    registry->adapters[layer_id] = adapter;
+    pthread_rwlock_unlock(&registry->rwlock);
+    return 0;
+}
+
+adapter_base_t* adapter_registry_get(adapter_registry_t* registry, uint32_t layer_id)
+{
+    if (!registry || layer_id >= TOPOLOGY_LAYER_MAX) return NULL;
+    adapter_base_t* result;
+    pthread_rwlock_rdlock(&registry->rwlock);
+    result = registry->adapters[layer_id];
+    pthread_rwlock_unlock(&registry->rwlock);
+    return result;
+}


### PR DESCRIPTION
## Summary
- add Hotwiring Adapter skeleton headers and sources
- stub out registry and orchestrator for adapter transitions
- document adapter interface

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862aaaf7d088327bdc7fadc12d0b9f9