### PR TITLE
Implement basic adapter infrastructure

### DIFF
--- a/libpolycall/include/polycall/core/topology/topology_manager.h
+++ b/libpolycall/include/polycall/core/topology/topology_manager.h
@@ -1,0 +1,27 @@
+#ifndef TOPOLOGY_MANAGER_H
+#define TOPOLOGY_MANAGER_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct topology_manager topology_manager_t;
+
+enum {
+    TOPOLOGY_LAYER_PYTHON = 0,
+    TOPOLOGY_LAYER_GO,
+    TOPOLOGY_LAYER_NODEJS,
+    TOPOLOGY_LAYER_MAX
+};
+
+int topology_manager_validate_transition(topology_manager_t* manager,
+                                         uint32_t from_layer,
+                                         uint32_t to_layer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TOPOLOGY_MANAGER_H

--- a/libpolycall/include/polycall/core/trace/polycall_trace.h
+++ b/libpolycall/include/polycall/core/trace/polycall_trace.h
@@ -1,0 +1,8 @@
+#ifndef POLYCALL_TRACE_H
+#define POLYCALL_TRACE_H
+
+typedef struct trace_event {
+    const char* message;
+} trace_event_t;
+
+#endif // POLYCALL_TRACE_H

--- a/libpolycall/src/core/CMakeLists.txt
+++ b/libpolycall/src/core/CMakeLists.txt
@@ -1,10 +1,16 @@
 # Core library source files
 set(CORE_SOURCES
-	${CMAKE_CURRENT_SOURCE_DIR}/polycall.c
-	${CMAKE_CURRENT_SOURCE_DIR}/polycall/polycall_config.c
-	${CMAKE_CURRENT_SOURCE_DIR}/polycall/polycall_context.c
-	${CMAKE_CURRENT_SOURCE_DIR}/polycall/polycall_error.c
-	${CMAKE_CURRENT_SOURCE_DIR}/polycall/polycall_memory.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/polycall.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/polycall/polycall_config.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/polycall/polycall_context.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/polycall/polycall_error.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/polycall/polycall_memory.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/adapters/adapter_base.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/adapters/adapter_registry.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/adapters/adapter_orchestrator.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/adapters/python_adapter.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/adapters/go_adapter.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/adapters/nodejs_adapter.c
 )
 # Create development workflow target
 add_custom_target(dev_workflow

--- a/libpolycall/src/core/adapters/adapter_base.c
+++ b/libpolycall/src/core/adapters/adapter_base.c
@@ -1,0 +1,46 @@
+#include "adapter_base.h"
+#include <stdlib.h>
+
+int adapter_base_init(adapter_base_t* adapter, topology_manager_t* manager) {
+    if (!adapter || !manager) {
+        return -1;
+    }
+    adapter->manager = manager;
+    atomic_init(&adapter->ref_count, 1);
+    pthread_mutex_init(&adapter->mutex, NULL);
+    return 0;
+}
+
+int adapter_base_acquire(adapter_base_t* adapter) {
+    if (!adapter) return -1;
+    atomic_fetch_add_explicit(&adapter->ref_count, 1, memory_order_relaxed);
+    return 0;
+}
+
+int adapter_base_release(adapter_base_t* adapter) {
+    if (!adapter) return -1;
+    if (atomic_fetch_sub_explicit(&adapter->ref_count, 1, memory_order_acq_rel) == 1) {
+        if (adapter->vtable && adapter->vtable->cleanup) {
+            adapter->vtable->cleanup(adapter);
+        }
+        pthread_mutex_destroy(&adapter->mutex);
+        free(adapter);
+    }
+    return 0;
+}
+
+int adapter_execute_transition(adapter_base_t* adapter,
+                              uint64_t thread_id,
+                              uint32_t target_layer) {
+    if (!adapter || !adapter->manager) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&adapter->mutex);
+    int result = topology_manager_validate_transition(
+        adapter->manager,
+        adapter->adapter_layer_id,
+        target_layer);
+    pthread_mutex_unlock(&adapter->mutex);
+    return result;
+}

--- a/libpolycall/src/core/adapters/adapter_base.h
+++ b/libpolycall/src/core/adapters/adapter_base.h
@@ -1,0 +1,45 @@
+#ifndef ADAPTER_BASE_H
+#define ADAPTER_BASE_H
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+
+#include "polycall/core/topology/topology_manager.h"
+#include "polycall/core/trace/polycall_trace.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct adapter_vtable {
+    int (*init)(void* adapter, topology_manager_t* manager);
+    int (*enter_layer)(void* adapter, uint64_t thread_id, uint32_t layer_id);
+    int (*exit_layer)(void* adapter, uint64_t thread_id);
+    int (*validate_transition)(void* adapter, uint32_t from, uint32_t to);
+    int (*emit_trace)(void* adapter, trace_event_t* event);
+    int (*cleanup)(void* adapter);
+} adapter_vtable_t;
+
+typedef struct adapter_base {
+    adapter_vtable_t* vtable;
+    topology_manager_t* manager;
+    atomic_int ref_count;
+    pthread_mutex_t mutex;
+    void* language_specific_data;
+    uint32_t adapter_layer_id;
+} adapter_base_t;
+
+int adapter_base_init(adapter_base_t* adapter, topology_manager_t* manager);
+int adapter_base_acquire(adapter_base_t* adapter);
+int adapter_base_release(adapter_base_t* adapter);
+
+int adapter_execute_transition(adapter_base_t* adapter,
+                              uint64_t thread_id,
+                              uint32_t target_layer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ADAPTER_BASE_H

--- a/libpolycall/src/core/adapters/adapter_orchestrator.c
+++ b/libpolycall/src/core/adapters/adapter_orchestrator.c
@@ -1,0 +1,21 @@
+#include "adapter_registry.h"
+
+int adapter_orchestrate_transition(adapter_registry_t* registry,
+                                  uint64_t thread_id,
+                                  uint32_t from_layer,
+                                  uint32_t to_layer) {
+    pthread_rwlock_rdlock(&registry->rwlock);
+    adapter_base_t* from = registry->adapters[from_layer];
+    adapter_base_t* to = registry->adapters[to_layer];
+    pthread_rwlock_unlock(&registry->rwlock);
+    if (!from || !to) return -1;
+    int result = 0;
+    if (from->vtable && from->vtable->exit_layer) {
+        result = from->vtable->exit_layer(from, thread_id);
+        if (result != 0) return result;
+    }
+    if (to->vtable && to->vtable->enter_layer) {
+        result = to->vtable->enter_layer(to, thread_id, to_layer);
+    }
+    return result;
+}

--- a/libpolycall/src/core/adapters/adapter_registry.c
+++ b/libpolycall/src/core/adapters/adapter_registry.c
@@ -1,0 +1,30 @@
+#include "adapter_registry.h"
+#include <stdlib.h>
+
+int adapter_registry_init(adapter_registry_t* registry, topology_manager_t* manager) {
+    if (!registry || !manager) return -1;
+    registry->manager = manager;
+    pthread_rwlock_init(&registry->rwlock, NULL);
+    for (size_t i = 0; i < TOPOLOGY_LAYER_MAX; i++) {
+        registry->adapters[i] = NULL;
+    }
+    return 0;
+}
+
+int adapter_registry_register(adapter_registry_t* registry,
+                             uint32_t layer_id,
+                             adapter_base_t* adapter) {
+    if (!registry || !adapter || layer_id >= TOPOLOGY_LAYER_MAX) return -1;
+    pthread_rwlock_wrlock(&registry->rwlock);
+    registry->adapters[layer_id] = adapter;
+    pthread_rwlock_unlock(&registry->rwlock);
+    return 0;
+}
+
+adapter_base_t* adapter_registry_get(adapter_registry_t* registry, uint32_t layer_id) {
+    if (!registry || layer_id >= TOPOLOGY_LAYER_MAX) return NULL;
+    pthread_rwlock_rdlock(&registry->rwlock);
+    adapter_base_t* a = registry->adapters[layer_id];
+    pthread_rwlock_unlock(&registry->rwlock);
+    return a;
+}

--- a/libpolycall/src/core/adapters/adapter_registry.h
+++ b/libpolycall/src/core/adapters/adapter_registry.h
@@ -1,0 +1,21 @@
+#ifndef ADAPTER_REGISTRY_H
+#define ADAPTER_REGISTRY_H
+
+#include <pthread.h>
+#include <stdint.h>
+
+#include "adapter_base.h"
+
+typedef struct adapter_registry {
+    adapter_base_t* adapters[TOPOLOGY_LAYER_MAX];
+    pthread_rwlock_t rwlock;
+    topology_manager_t* manager;
+} adapter_registry_t;
+
+int adapter_registry_init(adapter_registry_t* registry, topology_manager_t* manager);
+int adapter_registry_register(adapter_registry_t* registry,
+                             uint32_t layer_id,
+                             adapter_base_t* adapter);
+adapter_base_t* adapter_registry_get(adapter_registry_t* registry, uint32_t layer_id);
+
+#endif // ADAPTER_REGISTRY_H

--- a/libpolycall/src/core/adapters/go_adapter.c
+++ b/libpolycall/src/core/adapters/go_adapter.c
@@ -1,0 +1,54 @@
+#include "adapter_base.h"
+#include <stdlib.h>
+
+typedef struct go_adapter {
+    adapter_base_t base;
+    uintptr_t go_handle;
+    pthread_t owner_thread;
+} go_adapter_t;
+
+static int go_adapter_init(void* adapter, topology_manager_t* manager) {
+    go_adapter_t* go = (go_adapter_t*)adapter;
+    if (adapter_base_init(&go->base, manager) != 0) return -1;
+    go->base.adapter_layer_id = TOPOLOGY_LAYER_GO;
+    go->owner_thread = pthread_self();
+    return 0;
+}
+
+static int go_adapter_enter_layer(void* adapter, uint64_t thread_id, uint32_t layer_id) {
+    go_adapter_t* go = (go_adapter_t*)adapter;
+    if (!pthread_equal(pthread_self(), go->owner_thread)) {
+        return -1;
+    }
+    return adapter_execute_transition(&go->base, thread_id, layer_id);
+}
+
+static int go_adapter_exit_layer(void* adapter, uint64_t thread_id) {
+    (void)adapter; (void)thread_id;
+    return 0;
+}
+
+static int go_adapter_cleanup(void* adapter) {
+    (void)adapter;
+    return 0;
+}
+
+adapter_base_t* create_go_adapter(topology_manager_t* manager, uintptr_t handle) {
+    go_adapter_t* adapter = calloc(1, sizeof(go_adapter_t));
+    if (!adapter) return NULL;
+    adapter->go_handle = handle;
+    static adapter_vtable_t vt = {
+        .init = go_adapter_init,
+        .enter_layer = go_adapter_enter_layer,
+        .exit_layer = go_adapter_exit_layer,
+        .validate_transition = NULL,
+        .emit_trace = NULL,
+        .cleanup = go_adapter_cleanup
+    };
+    adapter->base.vtable = &vt;
+    if (adapter->base.vtable->init(adapter, manager) != 0) {
+        free(adapter);
+        return NULL;
+    }
+    return &adapter->base;
+}

--- a/libpolycall/src/core/adapters/nodejs_adapter.c
+++ b/libpolycall/src/core/adapters/nodejs_adapter.c
@@ -1,0 +1,61 @@
+#include "adapter_base.h"
+#include <node_api.h>
+#include <stdlib.h>
+
+typedef struct nodejs_adapter {
+    adapter_base_t base;
+    napi_env env;
+    napi_ref callback_ref;
+    uv_async_t* async_handle;
+} nodejs_adapter_t;
+
+static int nodejs_adapter_init(void* adapter, topology_manager_t* manager) {
+    nodejs_adapter_t* na = (nodejs_adapter_t*)adapter;
+    if (adapter_base_init(&na->base, manager) != 0) return -1;
+    na->base.adapter_layer_id = TOPOLOGY_LAYER_NODEJS;
+    return 0;
+}
+
+static int nodejs_adapter_enter_layer(void* adapter,
+                                     uint64_t thread_id,
+                                     uint32_t layer_id) {
+    nodejs_adapter_t* na = (nodejs_adapter_t*)adapter;
+    napi_handle_scope scope;
+    napi_open_handle_scope(na->env, &scope);
+    int result = adapter_execute_transition(&na->base, thread_id, layer_id);
+    if (result == 0 && na->async_handle) {
+        uv_async_send(na->async_handle);
+    }
+    napi_close_handle_scope(na->env, scope);
+    return result;
+}
+
+static int nodejs_adapter_exit_layer(void* adapter, uint64_t thread_id) {
+    (void)adapter; (void)thread_id;
+    return 0;
+}
+
+static int nodejs_adapter_cleanup(void* adapter) {
+    (void)adapter;
+    return 0;
+}
+
+adapter_base_t* create_nodejs_adapter(topology_manager_t* manager, napi_env env) {
+    nodejs_adapter_t* adapter = calloc(1, sizeof(nodejs_adapter_t));
+    if (!adapter) return NULL;
+    adapter->env = env;
+    static adapter_vtable_t vt = {
+        .init = nodejs_adapter_init,
+        .enter_layer = nodejs_adapter_enter_layer,
+        .exit_layer = nodejs_adapter_exit_layer,
+        .validate_transition = NULL,
+        .emit_trace = NULL,
+        .cleanup = nodejs_adapter_cleanup
+    };
+    adapter->base.vtable = &vt;
+    if (adapter->base.vtable->init(adapter, manager) != 0) {
+        free(adapter);
+        return NULL;
+    }
+    return &adapter->base;
+}

--- a/libpolycall/src/core/adapters/python_adapter.c
+++ b/libpolycall/src/core/adapters/python_adapter.c
@@ -1,0 +1,62 @@
+#include "adapter_base.h"
+#include <Python.h>
+#include <stdlib.h>
+
+typedef struct python_adapter {
+    adapter_base_t base;
+    PyObject* callback_dict;
+    PyGILState_STATE gil_state;
+} python_adapter_t;
+
+static int python_adapter_init(void* adapter, topology_manager_t* manager) {
+    python_adapter_t* py = (python_adapter_t*)adapter;
+    if (adapter_base_init(&py->base, manager) != 0) return -1;
+    py->base.adapter_layer_id = TOPOLOGY_LAYER_PYTHON;
+    py->callback_dict = PyDict_New();
+    if (!py->callback_dict) return -1;
+    return 0;
+}
+
+static int python_adapter_enter_layer(void* adapter,
+                                     uint64_t thread_id,
+                                     uint32_t layer_id) {
+    python_adapter_t* py = (python_adapter_t*)adapter;
+    py->gil_state = PyGILState_Ensure();
+    int result = adapter_execute_transition(&py->base, thread_id, layer_id);
+    if (result != 0) {
+        PyGILState_Release(py->gil_state);
+    }
+    return result;
+}
+
+static int python_adapter_exit_layer(void* adapter, uint64_t thread_id) {
+    python_adapter_t* py = (python_adapter_t*)adapter;
+    PyGILState_Release(py->gil_state);
+    (void)thread_id;
+    return 0;
+}
+
+static int python_adapter_cleanup(void* adapter) {
+    python_adapter_t* py = (python_adapter_t*)adapter;
+    Py_XDECREF(py->callback_dict);
+    return 0;
+}
+
+adapter_base_t* create_python_adapter(topology_manager_t* manager) {
+    python_adapter_t* adapter = calloc(1, sizeof(python_adapter_t));
+    if (!adapter) return NULL;
+    static adapter_vtable_t vt = {
+        .init = python_adapter_init,
+        .enter_layer = python_adapter_enter_layer,
+        .exit_layer = python_adapter_exit_layer,
+        .validate_transition = NULL,
+        .emit_trace = NULL,
+        .cleanup = python_adapter_cleanup
+    };
+    adapter->base.vtable = &vt;
+    if (adapter->base.vtable->init(adapter, manager) != 0) {
+        free(adapter);
+        return NULL;
+    }
+    return &adapter->base;
+}


### PR DESCRIPTION
## Summary
- add initial adapter base and registry headers
- implement Python, Go and Node.js adapters
- expose adapter orchestrator for cross-layer transitions
- update core CMake list with adapter sources

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6862aaaf7d088327bdc7fadc12d0b9f9