### PR TITLE
Add Hotwire Architecture TODO entry

### DIFF
--- a/libpolycall/docs/TODO.md
+++ b/libpolycall/docs/TODO.md
@@ -363,3 +363,5 @@ endif()
 5. The security policy enforcement system must provide comprehensive audit logging for compliance verification and security incident investigation.
 
 This architecture integrates with the existing LibPolyCall networking protocol while extending its capabilities through the micro and edge commands, maintaining the program-first approach that characterizes the project.
+### Pending TODO Items
+- [ ] Outline integration points with the Hotwire Architecture for cross-language execution.


### PR DESCRIPTION
## Summary
- add a pending TODO in the docs referencing Hotwire Architecture

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862aa3bba58832795c91440a2a0e543